### PR TITLE
Fix for cached image checking using xbmcvfs + bump version

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.embuary.helper" name="Embuary Helper" version="1.2.14" provider-name="sualfred">
+<addon id="script.embuary.helper" name="Embuary Helper" version="1.2.15" provider-name="sualfred">
 	<requires>
 		<import addon="xbmc.python" version="2.26.0"/>
 		<import addon="script.module.pil" version="1.1.7"/>

--- a/resources/lib/image.py
+++ b/resources/lib/image.py
@@ -67,10 +67,10 @@ def image_blur(image,radius):
 
         for i in range(1, 4):
             try:
-                if os.path.isfile(xbmc_cache_file):
+                if xbmcvfs.exists(xbmc_cache_file):
                     img = Image.open(xbmc.translatePath(xbmc_cache_file))
                     break
-                elif os.path.isfile(xbmc_vid_cache_file):
+                elif xbmcvfs.exists(xbmc_vid_cache_file):
                     img = Image.open(xbmc.translatePath(xbmc_vid_cache_file))
                     break
                 else:


### PR DESCRIPTION
As discussed in this issue https://github.com/sualfred/script.embuary.helper/issues/1 and on Kodi forum:- https://forum.kodi.tv/showthread.php?tid=345318&pid=2874052#pid2874052