### PR TITLE
Add new info label color_noalpha

### DIFF
--- a/resources/lib/image.py
+++ b/resources/lib/image.py
@@ -52,6 +52,7 @@ def image_filter(prop='listitem',file=None,radius=BLUR_RADIUS):
             blurred_image, imagecolor = image_blur(image,radius)
             winprop(prop + '_blurred', blurred_image)
             winprop(prop + '_color', imagecolor)
+            winprop(prop + '_color_noalpha', imagecolor[2:])
 
 
 def image_blur(image,radius):


### PR DESCRIPTION
Add a new info label listitem_color_noalpha that contains just the rgb portion of the listitem_color info label.

This is a simple non-breaking change that makes it easy for skin creators to add in there own alpha values to the already available listitem_color info label, at the moment the alpha is fixed to hex FF and cannot be changed, with the new info label any alpha value can easily be add like so:-

```
<variable name="mynewcolor">
  <value>$INFO[Window(home).Property(listitem_color_noalpha),a0]</value>
</variable>
```

and then used:-

`<colordiffuse>$VAR[mynewcolor]</colordiffuse>`




