### PR TITLE
Update getgenre to include fanart

### DIFF
--- a/resources/lib/plugin_content.py
+++ b/resources/lib/plugin_content.py
@@ -693,10 +693,9 @@ class PluginContent(object):
 
             if self.tag:
                 xsp = '{"rules":{"and":[{"field":"genre","operator":"is","value":["%s"]},{"field":"tag","operator":"is","value":["%s"]}]},"type":"%ss"}' % (genre['label'], self.tag, self.dbtype)
+                genre['url'] = 'videodb://{0}s/titles/?xsp={1}'.format(self.dbtype, url_quote(xsp))
             else:
-                xsp = '{"rules":{"and":[{"field":"genre","operator":"is","value":["%s"]}]},"type":"%ss"}' % (genre['label'],self.dbtype)
-
-            genre['url'] = 'videodb://{0}s/titles/?xsp={1}'.format(self.dbtype, url_quote(xsp))
+                genre['url'] = 'videodb://{0}s/genres/{1}/'.format(self.dbtype, genre['genreid'])
 
             genres.append(genre)
 


### PR DESCRIPTION
Update the Get movie/tvshow genres call.

`plugin://script.embuary.helper/?info=getgenre&type=movie&collage={true/false}`

`collage` is optional and is used to disable the generating of the collage images, if omitted the default will be `True` so as not to break any skin using the old syntax.

If `collage` is set to `False` then `ListItem.thumb` will be set to the first poster `ListItem.Property(poster.0)`

The following properties are now also set:-

ListItem.Property(fanart.%i) = random fanart of the genre (%i = 0,1,2,3)
ListItem.Art(fanart) = random fanart 0

Addition:- Use correct library path for genres that don't require tags, this will correctly set the Content.FolderName to the genre. Useful for creating breadcrumbs.